### PR TITLE
Try to address the large zip file download issue

### DIFF
--- a/static/ml-func-plugins.js
+++ b/static/ml-func-plugins.js
@@ -14,7 +14,7 @@ const ML_AUDIO_FETCH_TIMEOUT_BY_LEVEL_MS = {
     jymaster: 1800000
 };
 const ML_DEFAULT_AUDIO_FETCH_TIMEOUT_MS = 900000;
-const ML_BLOB_URL_REVOKE_DELAY_MS = 10000;
+const ML_BLOB_URL_REVOKE_DELAY_MS = 300000;
 
 function ml_create_timeout_signal(parentSignal, timeoutMs, message) {
     const controller = new AbortController();

--- a/static/ml-func-plugins.js
+++ b/static/ml-func-plugins.js
@@ -14,6 +14,7 @@ const ML_AUDIO_FETCH_TIMEOUT_BY_LEVEL_MS = {
     jymaster: 1800000
 };
 const ML_DEFAULT_AUDIO_FETCH_TIMEOUT_MS = 900000;
+const ML_BLOB_URL_REVOKE_DELAY_MS = 10000;
 
 function ml_create_timeout_signal(parentSignal, timeoutMs, message) {
     const controller = new AbortController();
@@ -842,8 +843,11 @@ function ml_trigger_blob_download(blob, fileName) {
     document.body.appendChild(a);
     a.click();
     document.body.removeChild(a);
-    URL.revokeObjectURL(blobUrl);
-    console.log(`文件 "${fileName}" 已开始下载。`);
+
+    // Chromium acquires large Blob downloads asynchronously. Revoking the URL
+    // in the same turn can make the browser report a network/read failure.
+    setTimeout(() => URL.revokeObjectURL(blobUrl), ML_BLOB_URL_REVOKE_DELAY_MS);
+    console.log(`文件 "${fileName}" 已提交给浏览器下载。`);
 }
 
 // 定义下载函数

--- a/static/ml-func-plugins.js
+++ b/static/ml-func-plugins.js
@@ -14,7 +14,9 @@ const ML_AUDIO_FETCH_TIMEOUT_BY_LEVEL_MS = {
     jymaster: 1800000
 };
 const ML_DEFAULT_AUDIO_FETCH_TIMEOUT_MS = 900000;
-const ML_BLOB_URL_REVOKE_DELAY_MS = 300000;
+const ML_BLOB_DOWNLOAD_HANDOFF_DELAY_MS = 10000;
+const ML_BLOB_DOWNLOAD_FOCUS_SETTLE_MS = 1000;
+let ml_browser_download_slot = Promise.resolve();
 
 function ml_create_timeout_signal(parentSignal, timeoutMs, message) {
     const controller = new AbortController();
@@ -835,32 +837,78 @@ async function ml_build_music_file(al_name, ar_name, processedLyrics, name, pic,
     }
 };
 
-function ml_trigger_blob_download(blob, fileName) {
+function ml_with_browser_download_slot(operation) {
+    const pendingOperation = ml_browser_download_slot.then(operation, operation);
+    ml_browser_download_slot = pendingOperation.catch(() => {});
+    return pendingOperation;
+}
+
+function ml_wait_for_browser_download_handoff() {
+    return new Promise(resolve => {
+        let didBlur = false;
+        let handoffTimer = null;
+        let focusTimer = null;
+
+        const cleanup = () => {
+            window.removeEventListener('blur', handleBlur);
+            window.removeEventListener('focus', handleFocus);
+            clearTimeout(handoffTimer);
+            clearTimeout(focusTimer);
+        };
+        const finish = () => {
+            cleanup();
+            resolve();
+        };
+        const handleBlur = () => {
+            didBlur = true;
+            clearTimeout(handoffTimer);
+        };
+        const handleFocus = () => {
+            if (didBlur && focusTimer === null) {
+                focusTimer = setTimeout(finish, ML_BLOB_DOWNLOAD_FOCUS_SETTLE_MS);
+            }
+        };
+
+        window.addEventListener('blur', handleBlur);
+        window.addEventListener('focus', handleFocus);
+        handoffTimer = setTimeout(finish, ML_BLOB_DOWNLOAD_HANDOFF_DELAY_MS);
+    });
+}
+
+async function ml_trigger_blob_download(blob, fileName) {
     const blobUrl = URL.createObjectURL(blob);
     const a = document.createElement('a');
     a.href = blobUrl;
     a.download = fileName;
     document.body.appendChild(a);
-    a.click();
-    document.body.removeChild(a);
+    const handoffPromise = ml_wait_for_browser_download_handoff();
 
-    // Chromium acquires large Blob downloads asynchronously. Revoking the URL
-    // in the same turn can make the browser report a network/read failure.
-    setTimeout(() => URL.revokeObjectURL(blobUrl), ML_BLOB_URL_REVOKE_DELAY_MS);
-    console.log(`文件 "${fileName}" 已提交给浏览器下载。`);
+    try {
+        a.click();
+        document.body.removeChild(a);
+        await handoffPromise;
+        console.log(`文件 "${fileName}" 已提交给浏览器下载。`);
+    } finally {
+        if (a.parentNode) {
+            a.parentNode.removeChild(a);
+        }
+        URL.revokeObjectURL(blobUrl);
+    }
 }
 
 // 定义下载函数
 async function ml_music_download(al_name, ar_name, processedLyrics, name, pic, url, level = null, trackNumber = null, totalTracks = null, abortSignal = null) {
-    try {
-        const musicFile = await ml_build_music_file(al_name, ar_name, processedLyrics, name, pic, url, level, trackNumber, totalTracks, abortSignal);
-        ml_trigger_blob_download(musicFile.blob, musicFile.fileName);
-    } catch (error) {
-        if (error?.name !== 'AbortError') {
-            ml_show_Alert('下载错误', '下载音乐时发生错误，请查看控制台获取详情。', 'error');
+    return ml_with_browser_download_slot(async () => {
+        try {
+            const musicFile = await ml_build_music_file(al_name, ar_name, processedLyrics, name, pic, url, level, trackNumber, totalTracks, abortSignal);
+            await ml_trigger_blob_download(musicFile.blob, musicFile.fileName);
+        } catch (error) {
+            if (error?.name !== 'AbortError') {
+                ml_show_Alert('下载错误', '下载音乐时发生错误，请查看控制台获取详情。', 'error');
+            }
+            throw error;
         }
-        throw error;
-    }
+    });
 };
 
 // multi-songs download

--- a/static/ml-task-manager.js
+++ b/static/ml-task-manager.js
@@ -106,8 +106,7 @@ function ml_create_task(options) {
         generatedFiles: [],
         usedFileNames: new Set(),
         folderFallbackNotified: false,
-        storageFailureCount: 0,
-        lastStorageError: null,
+        songFailureErrors: new Map(),
 
         // State management
         isPaused: false,
@@ -389,6 +388,10 @@ function ml_is_storage_io_error(error) {
         error?.name === 'QuotaExceededError' ||
         error?.name === 'UnknownError' ||
         /disk|space|quota|swap file|could not be read|file operation|i\/o/i.test(error?.message || '');
+}
+
+function ml_get_storage_failed_songs(task) {
+    return task.failedSongs.filter(song => ml_is_storage_io_error(task.songFailureErrors.get(song)));
 }
 
 async function ml_verify_directory_writable(directoryHandle) {
@@ -870,15 +873,15 @@ async function ml_execute_batch_task(task) {
 
                     task.completedCount++;
                     task.successCount++;
+                    task.songFailureErrors.delete(song);
                 } catch (error) {
                     if (task.status === ML_TASK_STATUS.CANCELLED || error?.name === 'AbortError') {
                         cancelledSongs.push(song);
                         return;
                     }
 
+                    task.songFailureErrors.set(song, error);
                     if (ml_is_storage_io_error(error)) {
-                        task.storageFailureCount++;
-                        task.lastStorageError = error;
                         console.warn(`Task ${task.id}: browser storage failed during ${error.mlFolderWriteStage || 'file processing'}.`, error);
                     }
 
@@ -924,10 +927,16 @@ async function ml_execute_batch_task(task) {
     task.progress = (task.completedCount / task.totalCount) * 100;
     task.remainingSongs = [];
 
-    if (task.failedSongs.length > 0 && task.storageFailureCount > 0) {
+    const storageFailedSongs = ml_get_storage_failed_songs(task);
+    if (storageFailedSongs.length > 0) {
+        const failedNames = task.failedSongs.map(song => song.name || song.id).join('\n');
+        const zipNotice = task.outputMode === ML_COLLECTION_DOWNLOAD_MODE.ZIP && task.generatedFiles.length > 0 ?
+            `ZIP压缩包只包含已成功下载的 ${task.successCount} 首歌曲。\n\n` : '';
+        const otherFailedCount = task.failedCount - storageFailedSongs.length;
+        const otherFailureNotice = otherFailedCount > 0 ? `另有 ${otherFailedCount} 首因其他原因失败。\n\n` : '';
         ml_show_Alert(
-            '浏览器存储失败',
-            `有 ${task.failedCount} 首歌曲在写入浏览器临时存储或目标文件夹时失败。请释放系统盘和目标磁盘空间、降低同时下载数后重试。`,
+            otherFailedCount > 0 ? '部分歌曲下载失败' : '浏览器存储失败',
+            `${zipNotice}有 ${storageFailedSongs.length} 首歌曲在写入浏览器临时存储或目标文件夹时失败。${otherFailureNotice}请释放系统盘和目标磁盘空间、降低同时下载数后重试。\n\n${failedNames}`,
             'error'
         );
     } else if (task.failedSongs.length > 0 && task.outputMode === ML_COLLECTION_DOWNLOAD_MODE.ZIP && task.generatedFiles.length > 0) {

--- a/static/ml-task-manager.js
+++ b/static/ml-task-manager.js
@@ -106,6 +106,8 @@ function ml_create_task(options) {
         generatedFiles: [],
         usedFileNames: new Set(),
         folderFallbackNotified: false,
+        storageFailureCount: 0,
+        lastStorageError: null,
 
         // State management
         isPaused: false,
@@ -225,6 +227,10 @@ async function ml_add_batch_task(songs, title, description, cover, level, option
 function ml_get_collection_download_mode() {
     const mode = localStorage.getItem('ml_collection_download_mode') || ML_COLLECTION_DOWNLOAD_MODE.INDIVIDUAL;
     return Object.values(ML_COLLECTION_DOWNLOAD_MODE).includes(mode) ? mode : ML_COLLECTION_DOWNLOAD_MODE.INDIVIDUAL;
+}
+
+function ml_task_uses_browser_download(task) {
+    return task.type === ML_TASK_TYPE.SINGLE || task.outputMode !== ML_COLLECTION_DOWNLOAD_MODE.FOLDER;
 }
 
 async function ml_prompt_collection_download_name(defaultName, outputMode) {
@@ -370,10 +376,19 @@ async function ml_ensure_directory_write_permission(directoryHandle) {
 }
 
 function ml_is_folder_write_blocked_error(error) {
+    if (ml_is_storage_io_error(error)) return false;
+
     return error?.name === 'NotAllowedError' ||
         error?.name === 'SecurityError' ||
         error?.name === 'AbortError' ||
         /system file|permission|denied|not allowed|security/i.test(error?.message || '');
+}
+
+function ml_is_storage_io_error(error) {
+    return error?.name === 'NotReadableError' ||
+        error?.name === 'QuotaExceededError' ||
+        error?.name === 'UnknownError' ||
+        /disk|space|quota|swap file|could not be read|file operation|i\/o/i.test(error?.message || '');
 }
 
 async function ml_verify_directory_writable(directoryHandle) {
@@ -490,6 +505,49 @@ async function ml_get_unique_folder_file_name(folderHandle, fileName, usedFileNa
         }
 
         index++;
+    }
+}
+
+async function ml_write_blob_to_folder(folderHandle, fileName, blob) {
+    let writable = null;
+    let stage = 'get-file-handle';
+    let fileHandleAcquired = false;
+
+    try {
+        const fileHandle = await folderHandle.getFileHandle(fileName, { create: true });
+        fileHandleAcquired = true;
+        stage = 'create-writable';
+        writable = await fileHandle.createWritable();
+        stage = 'write';
+        await writable.write(blob);
+        stage = 'close';
+        await writable.close();
+        writable = null;
+    } catch (error) {
+        if (writable && typeof writable.abort === 'function') {
+            try {
+                await writable.abort();
+            } catch (abortError) {
+                console.warn(`Failed to abort folder writer for ${fileName}:`, abortError);
+            }
+        }
+
+        if (fileHandleAcquired && typeof folderHandle.removeEntry === 'function') {
+            try {
+                await folderHandle.removeEntry(fileName);
+            } catch (removeError) {
+                if (removeError?.name !== 'NotFoundError') {
+                    console.warn(`Failed to remove incomplete folder file ${fileName}:`, removeError);
+                }
+            }
+        }
+
+        try {
+            error.mlFolderWriteStage = stage;
+        } catch (_) {
+            // Some browser-provided DOMException objects are not extensible.
+        }
+        throw error;
     }
 }
 
@@ -711,12 +769,12 @@ async function ml_save_task_music_file(task, response, processedLyrics, song) {
         let fileName = null;
         try {
             fileName = await ml_get_unique_folder_file_name(task.folderHandle, musicFile.fileName, task.usedFileNames);
-            const fileHandle = await task.folderHandle.getFileHandle(fileName, { create: true });
-            const writable = await fileHandle.createWritable();
-            await writable.write(musicFile.blob);
-            await writable.close();
+            await ml_write_blob_to_folder(task.folderHandle, fileName, musicFile.blob);
         } catch (error) {
             if (!ml_is_folder_write_blocked_error(error)) {
+                if (fileName) {
+                    task.usedFileNames.delete(fileName);
+                }
                 throw error;
             }
 
@@ -818,6 +876,12 @@ async function ml_execute_batch_task(task) {
                         return;
                     }
 
+                    if (ml_is_storage_io_error(error)) {
+                        task.storageFailureCount++;
+                        task.lastStorageError = error;
+                        console.warn(`Task ${task.id}: browser storage failed during ${error.mlFolderWriteStage || 'file processing'}.`, error);
+                    }
+
                     console.warn(`Task ${task.id}: song ${song.id || song.name || 'unknown'} failed, will retry if attempts remain.`, error);
                     currentRoundFailed.push(song);
                 }
@@ -860,7 +924,13 @@ async function ml_execute_batch_task(task) {
     task.progress = (task.completedCount / task.totalCount) * 100;
     task.remainingSongs = [];
 
-    if (task.failedSongs.length > 0 && task.outputMode === ML_COLLECTION_DOWNLOAD_MODE.ZIP && task.generatedFiles.length > 0) {
+    if (task.failedSongs.length > 0 && task.storageFailureCount > 0) {
+        ml_show_Alert(
+            '浏览器存储失败',
+            `有 ${task.failedCount} 首歌曲在写入浏览器临时存储或目标文件夹时失败。请释放系统盘和目标磁盘空间、降低同时下载数后重试。`,
+            'error'
+        );
+    } else if (task.failedSongs.length > 0 && task.outputMode === ML_COLLECTION_DOWNLOAD_MODE.ZIP && task.generatedFiles.length > 0) {
         const failedNames = task.failedSongs.map(song => song.name || song.id).join('\n');
         ml_show_Alert('部分歌曲下载失败', `ZIP压缩包只包含已成功下载的 ${task.successCount} 首歌曲。\n失败: ${task.failedCount} 首\n\n${failedNames}`, 'warning');
     }
@@ -1153,7 +1223,7 @@ function ml_create_task_item_html(task) {
         let statusClass = '';
         let statusIcon = '';
         if (task.status === ML_TASK_STATUS.COMPLETED) {
-            statusText = '完成';
+            statusText = ml_task_uses_browser_download(task) ? '已提交' : '完成';
             statusClass = 'bg-success';
             statusIcon = '<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="currentColor" viewBox="0 0 16 16"><path d="M16 8A8 8 0 1 1 0 8a8 8 0 0 1 16 0zm-3.97-3.03a.75.75 0 0 0-1.08.022L7.477 9.417 5.384 7.323a.75.75 0 0 0-1.06 1.06L6.97 11.03a.75.75 0 0 0 1.079-.02l3.992-4.99a.75.75 0 0 0-.01-1.05z"/></svg>';
         } else if (task.status === ML_TASK_STATUS.FAILED) {
@@ -1422,6 +1492,14 @@ function ml_create_toast_html(toast) {
             </svg>`;
             typeText = '已完成';
             break;
+        case 'submitted':
+            typeClass = 'toast-completed';
+            typeIcon = `<svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" fill="currentColor" viewBox="0 0 16 16">
+                <path d="M.5 9.9a.5.5 0 0 1 .5.5v2.5a1 1 0 0 0 1 1h12a1 1 0 0 0 1-1v-2.5a.5.5 0 0 1 1 0v2.5a2 2 0 0 1-2 2H2a2 2 0 0 1-2-2v-2.5a.5.5 0 0 1 .5-.5z"/>
+                <path d="M7.646 11.854a.5.5 0 0 0 .708 0l3-3a.5.5 0 0 0-.708-.708L8.5 10.293V1.5a.5.5 0 0 0-1 0v8.793L5.354 8.146a.5.5 0 1 0-.708.708l3 3z"/>
+            </svg>`;
+            typeText = '已提交下载';
+            break;
         case 'search':
             typeClass = 'toast-search';
             typeIcon = `<svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" fill="currentColor" viewBox="0 0 16 16">
@@ -1551,12 +1629,15 @@ function ml_show_task_started_toast(task) {
  * 显示任务完成通知
  */
 function ml_show_task_completed_toast(task) {
+    const usesBrowserDownload = ml_task_uses_browser_download(task);
     ml_show_toast({
-        type: 'completed',
+        type: usesBrowserDownload ? 'submitted' : 'completed',
         title: task.title,
-        subtitle: task.type === ML_TASK_TYPE.BATCH ?
-            `${task.successCount}/${task.totalCount} 首歌曲下载完成` :
-            task.subtitle,
+        subtitle: usesBrowserDownload ?
+            (task.type === ML_TASK_TYPE.BATCH ?
+                `${task.successCount}/${task.totalCount} 首歌曲已提交，请在浏览器下载列表确认` :
+                '已提交，请在浏览器下载列表确认') :
+            `${task.successCount}/${task.totalCount} 首歌曲已写入文件夹`,
         cover: task.cover
     });
 }

--- a/static/ml-task-manager.js
+++ b/static/ml-task-manager.js
@@ -809,12 +809,20 @@ async function ml_finish_zip_task(task) {
         zip.file(file.fileName, file.blob);
     });
 
-    const zipBlob = await zip.generateAsync({ type: 'blob' });
-    if (task.status !== ML_TASK_STATUS.ACTIVE || task.isPaused) {
-        return;
-    }
+    let submitted = false;
+    await ml_with_browser_download_slot(async () => {
+        const zipBlob = await zip.generateAsync({ type: 'blob' });
+        if (task.status !== ML_TASK_STATUS.ACTIVE || task.isPaused) {
+            return;
+        }
 
-    ml_trigger_blob_download(zipBlob, `${ml_sanitize_path_segment(task.collectionName || task.title || 'download')}.zip`);
+        await ml_trigger_blob_download(zipBlob, `${ml_sanitize_path_segment(task.collectionName || task.title || 'download')}.zip`);
+        submitted = true;
+    });
+
+    if (submitted) {
+        task.generatedFiles = [];
+    }
 }
 
 /**

--- a/templates/ml-index.html
+++ b/templates/ml-index.html
@@ -342,7 +342,7 @@
                                 <label for="collection-download-mode" class="form-label">多曲下载方式</label>
                                 <select id="collection-download-mode" class="form-select">
                                     <option value="individual">单独文件</option>
-                                    <option value="zip">ZIP压缩包</option>
+                                    <option value="zip">ZIP压缩包 (Beta)</option>
                                     <option value="folder">指定文件夹 (Beta)</option>
                                 </select>
                             </div>

--- a/tests/download_helpers.test.js
+++ b/tests/download_helpers.test.js
@@ -23,25 +23,32 @@ function createJQueryStub() {
     };
 }
 
-function loadScript(relativePath, overrides = {}) {
+function loadScripts(relativePaths, overrides = {}) {
     const context = vm.createContext({
         console,
         document: {},
-        window: { addEventListener() {} },
+        window: { addEventListener() {}, removeEventListener() {} },
         DOMException,
         setTimeout,
         clearTimeout,
         $: createJQueryStub(),
         ...overrides
     });
-    const source = fs.readFileSync(path.join(projectRoot, relativePath), 'utf8');
-    vm.runInContext(source, context, { filename: relativePath });
+    for (const relativePath of relativePaths) {
+        const source = fs.readFileSync(path.join(projectRoot, relativePath), 'utf8');
+        vm.runInContext(source, context, { filename: relativePath });
+    }
     return context;
 }
 
-test('blob download URL remains valid until the cleanup timer runs', () => {
+function loadScript(relativePath, overrides = {}) {
+    return loadScripts([relativePath], overrides);
+}
+
+test('blob download URL remains valid until the browser handoff timer runs', async () => {
     const timers = [];
     const revokedUrls = [];
+    const listeners = {};
     let clicked = false;
     let appended = false;
     let removed = false;
@@ -69,13 +76,20 @@ test('blob download URL remains valid until the cleanup timer runs', () => {
                 }
             }
         },
+        window: {
+            addEventListener(type, listener) { listeners[type] = listener; },
+            removeEventListener(type, listener) {
+                if (listeners[type] === listener) delete listeners[type];
+            }
+        },
         setTimeout(callback, delay) {
             timers.push({ callback, delay });
             return timers.length;
-        }
+        },
+        clearTimeout() {}
     });
 
-    context.ml_trigger_blob_download({ size: 1024 }, 'song.flac');
+    const downloadPromise = context.ml_trigger_blob_download({ size: 1024 }, 'song.flac');
 
     assert.equal(anchor.href, 'blob:test-download');
     assert.equal(anchor.download, 'song.flac');
@@ -84,10 +98,88 @@ test('blob download URL remains valid until the cleanup timer runs', () => {
     assert.equal(removed, true);
     assert.deepEqual(revokedUrls, []);
     assert.equal(timers.length, 1);
-    assert.equal(timers[0].delay, 300000);
+    assert.equal(timers[0].delay, 10000);
 
     timers[0].callback();
+    await downloadPromise;
     assert.deepEqual(revokedUrls, ['blob:test-download']);
+});
+
+test('Save As handoff waits for window focus before revoking the Blob URL', async () => {
+    const listeners = {};
+    const timers = [];
+    const revokedUrls = [];
+    const context = loadScript('static/ml-func-plugins.js', {
+        URL: {
+            createObjectURL() { return 'blob:save-as'; },
+            revokeObjectURL(url) { revokedUrls.push(url); }
+        },
+        document: {
+            createElement() { return { click() {} }; },
+            body: { appendChild() {}, removeChild() {} }
+        },
+        window: {
+            addEventListener(type, listener) { listeners[type] = listener; },
+            removeEventListener(type, listener) {
+                if (listeners[type] === listener) delete listeners[type];
+            }
+        },
+        setTimeout(callback, delay) {
+            const timer = { callback, delay, cancelled: false };
+            timers.push(timer);
+            return timer;
+        },
+        clearTimeout(timer) {
+            if (timer) timer.cancelled = true;
+        }
+    });
+
+    const downloadPromise = context.ml_trigger_blob_download({ size: 1024 }, 'song.flac');
+    listeners.blur();
+
+    assert.equal(timers[0].cancelled, true);
+    assert.deepEqual(revokedUrls, []);
+
+    listeners.focus();
+    assert.equal(timers[1].delay, 1000);
+    timers[1].callback();
+    await downloadPromise;
+
+    assert.deepEqual(revokedUrls, ['blob:save-as']);
+});
+
+test('individual downloads acquire the browser slot before building a Blob', async () => {
+    const context = loadScript('static/ml-func-plugins.js');
+    const order = [];
+    let releaseFirstBuild;
+    const firstBuildGate = new Promise(resolve => { releaseFirstBuild = resolve; });
+
+    context.ml_build_music_file = async (_album, _artist, _lyrics, name) => {
+        order.push(`${name}-build-start`);
+        if (name === 'first') await firstBuildGate;
+        order.push(`${name}-build-end`);
+        return { blob: { size: 1024 }, fileName: `${name}.flac` };
+    };
+    context.ml_trigger_blob_download = async (_blob, fileName) => {
+        order.push(`${fileName}-trigger`);
+    };
+
+    const first = context.ml_music_download('', '', '', 'first', '', '');
+    const second = context.ml_music_download('', '', '', 'second', '', '');
+
+    await new Promise(resolve => setImmediate(resolve));
+    assert.deepEqual(order, ['first-build-start']);
+
+    releaseFirstBuild();
+    await Promise.all([first, second]);
+    assert.deepEqual(order, [
+        'first-build-start',
+        'first-build-end',
+        'first.flac-trigger',
+        'second-build-start',
+        'second-build-end',
+        'second.flac-trigger'
+    ]);
 });
 
 test('failed folder writes abort the writer, remove the partial file, and report the stage', async () => {
@@ -170,8 +262,36 @@ test('only final per-song storage errors affect the failure alert classification
     assert.equal(storageFailures[0], storageFailedSong);
 });
 
+test('successful ZIP submission releases retained source Blobs', async () => {
+    const context = loadScripts(['static/ml-func-plugins.js', 'static/ml-task-manager.js']);
+    let submittedName = null;
+    context.JSZip = class FakeZip {
+        file() {}
+        async generateAsync() { return { size: 2048 }; }
+    };
+    context.ml_with_browser_download_slot = operation => operation();
+    context.ml_trigger_blob_download = async (_blob, fileName) => {
+        submittedName = fileName;
+    };
+    const task = {
+        outputMode: 'zip',
+        generatedFiles: [
+            { fileName: 'one.flac', blob: { size: 1024 } },
+            { fileName: 'two.flac', blob: { size: 1024 } }
+        ],
+        status: 'active',
+        isPaused: false,
+        collectionName: 'Album'
+    };
+
+    await context.ml_finish_zip_task(task);
+
+    assert.equal(submittedName, 'Album.zip');
+    assert.equal(task.generatedFiles.length, 0);
+});
+
 test('a recovered storage retry does not classify another song network failure as storage', async () => {
-    const context = loadScript('static/ml-task-manager.js', {
+    const context = loadScripts(['static/ml-func-plugins.js', 'static/ml-task-manager.js'], {
         console: { log() {}, warn() {}, error() {} }
     });
     const recoveredSong = { id: 1, name: 'Recovered' };
@@ -179,7 +299,6 @@ test('a recovered storage retry does not classify another song network failure a
     const attempts = new Map();
     const alerts = [];
 
-    context.ml_max_try_times = 2;
     context.ml_get_concurrent_count = () => 1;
     context.ml_update_task_item = () => {};
     context.ml_show_Alert = (...args) => alerts.push(args);
@@ -231,5 +350,7 @@ test('a recovered storage retry does not classify another song network failure a
     assert.equal(task.failedSongs[0], networkFailedSong);
     assert.equal(task.songFailureErrors.has(recoveredSong), false);
     assert.equal(task.songFailureErrors.get(networkFailedSong).name, 'TypeError');
+    assert.equal(attempts.get(recoveredSong), 2);
+    assert.equal(attempts.get(networkFailedSong), 5);
     assert.equal(alerts.length, 0);
 });

--- a/tests/download_helpers.test.js
+++ b/tests/download_helpers.test.js
@@ -84,7 +84,7 @@ test('blob download URL remains valid until the cleanup timer runs', () => {
     assert.equal(removed, true);
     assert.deepEqual(revokedUrls, []);
     assert.equal(timers.length, 1);
-    assert.equal(timers[0].delay, 10000);
+    assert.equal(timers[0].delay, 300000);
 
     timers[0].callback();
     assert.deepEqual(revokedUrls, ['blob:test-download']);
@@ -147,4 +147,89 @@ test('browser-managed and direct-folder tasks use different completion semantics
     assert.equal(context.ml_task_uses_browser_download({ type: 'single', outputMode: 'individual' }), true);
     assert.equal(context.ml_task_uses_browser_download({ type: 'batch', outputMode: 'zip' }), true);
     assert.equal(context.ml_task_uses_browser_download({ type: 'batch', outputMode: 'folder' }), false);
+});
+
+test('only final per-song storage errors affect the failure alert classification', () => {
+    const context = loadScript('static/ml-task-manager.js');
+    const recoveredSong = { id: 1 };
+    const networkFailedSong = { id: 2 };
+    const storageFailedSong = { id: 3 };
+    const errors = new Map();
+
+    errors.set(recoveredSong, new DOMException('Could not read file', 'NotReadableError'));
+    errors.delete(recoveredSong);
+    errors.set(networkFailedSong, new TypeError('Failed to fetch'));
+    errors.set(storageFailedSong, new DOMException('Disk quota exceeded', 'QuotaExceededError'));
+
+    const storageFailures = context.ml_get_storage_failed_songs({
+        failedSongs: [networkFailedSong, storageFailedSong],
+        songFailureErrors: errors
+    });
+
+    assert.equal(storageFailures.length, 1);
+    assert.equal(storageFailures[0], storageFailedSong);
+});
+
+test('a recovered storage retry does not classify another song network failure as storage', async () => {
+    const context = loadScript('static/ml-task-manager.js', {
+        console: { log() {}, warn() {}, error() {} }
+    });
+    const recoveredSong = { id: 1, name: 'Recovered' };
+    const networkFailedSong = { id: 2, name: 'Network failure' };
+    const attempts = new Map();
+    const alerts = [];
+
+    context.ml_max_try_times = 2;
+    context.ml_get_concurrent_count = () => 1;
+    context.ml_update_task_item = () => {};
+    context.ml_show_Alert = (...args) => alerts.push(args);
+    context.ml_sanitize_lrc_timestamps = lyrics => lyrics;
+    context.ml_resolve_lrc_timestamp_conflicts = lyrics => lyrics;
+    context.ml_fetch_task_song_info = async () => ({
+        status: 200,
+        lyric: '',
+        tlyric: '',
+        al_name: '',
+        ar_name: '',
+        name: '',
+        pic: '',
+        url: ''
+    });
+    context.ml_save_task_music_file = async (_task, _response, _lyrics, song) => {
+        const attempt = (attempts.get(song) || 0) + 1;
+        attempts.set(song, attempt);
+        if (song === recoveredSong && attempt === 1) {
+            throw new DOMException('Could not read file', 'NotReadableError');
+        }
+        if (song === networkFailedSong) {
+            throw new TypeError('Failed to fetch');
+        }
+    };
+
+    const task = {
+        id: 10,
+        songs: [recoveredSong, networkFailedSong],
+        remainingSongs: null,
+        totalCount: 2,
+        completedCount: 0,
+        successCount: 0,
+        failedCount: 0,
+        failedSongs: [],
+        progress: 0,
+        outputMode: 'individual',
+        generatedFiles: [],
+        songFailureErrors: new Map(),
+        status: 'active',
+        isPaused: false,
+        abortController: null
+    };
+
+    await context.ml_execute_batch_task(task);
+
+    assert.equal(task.successCount, 1);
+    assert.equal(task.failedCount, 1);
+    assert.equal(task.failedSongs[0], networkFailedSong);
+    assert.equal(task.songFailureErrors.has(recoveredSong), false);
+    assert.equal(task.songFailureErrors.get(networkFailedSong).name, 'TypeError');
+    assert.equal(alerts.length, 0);
 });

--- a/tests/download_helpers.test.js
+++ b/tests/download_helpers.test.js
@@ -1,0 +1,150 @@
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const test = require('node:test');
+const vm = require('node:vm');
+
+const projectRoot = path.resolve(__dirname, '..');
+
+function createJQueryStub() {
+    return function jqueryStub() {
+        return {
+            ready() {},
+            on() {},
+            off() {},
+            each() {},
+            val() { return ''; },
+            text() {},
+            data() {},
+            prop() {},
+            addClass() {},
+            removeClass() {}
+        };
+    };
+}
+
+function loadScript(relativePath, overrides = {}) {
+    const context = vm.createContext({
+        console,
+        document: {},
+        window: { addEventListener() {} },
+        DOMException,
+        setTimeout,
+        clearTimeout,
+        $: createJQueryStub(),
+        ...overrides
+    });
+    const source = fs.readFileSync(path.join(projectRoot, relativePath), 'utf8');
+    vm.runInContext(source, context, { filename: relativePath });
+    return context;
+}
+
+test('blob download URL remains valid until the cleanup timer runs', () => {
+    const timers = [];
+    const revokedUrls = [];
+    let clicked = false;
+    let appended = false;
+    let removed = false;
+    const anchor = {
+        click() { clicked = true; }
+    };
+    const context = loadScript('static/ml-func-plugins.js', {
+        URL: {
+            createObjectURL() { return 'blob:test-download'; },
+            revokeObjectURL(url) { revokedUrls.push(url); }
+        },
+        document: {
+            createElement(tagName) {
+                assert.equal(tagName, 'a');
+                return anchor;
+            },
+            body: {
+                appendChild(element) {
+                    assert.equal(element, anchor);
+                    appended = true;
+                },
+                removeChild(element) {
+                    assert.equal(element, anchor);
+                    removed = true;
+                }
+            }
+        },
+        setTimeout(callback, delay) {
+            timers.push({ callback, delay });
+            return timers.length;
+        }
+    });
+
+    context.ml_trigger_blob_download({ size: 1024 }, 'song.flac');
+
+    assert.equal(anchor.href, 'blob:test-download');
+    assert.equal(anchor.download, 'song.flac');
+    assert.equal(clicked, true);
+    assert.equal(appended, true);
+    assert.equal(removed, true);
+    assert.deepEqual(revokedUrls, []);
+    assert.equal(timers.length, 1);
+    assert.equal(timers[0].delay, 10000);
+
+    timers[0].callback();
+    assert.deepEqual(revokedUrls, ['blob:test-download']);
+});
+
+test('failed folder writes abort the writer, remove the partial file, and report the stage', async () => {
+    const context = loadScript('static/ml-task-manager.js');
+    let aborted = false;
+    let removedName = null;
+    const error = new DOMException(
+        'The requested file could not be read, typically due to permission problems that have occurred after a reference to a file was acquired.',
+        'NotReadableError'
+    );
+    const writable = {
+        async write() { throw error; },
+        async close() { assert.fail('close should not run after write fails'); },
+        async abort() { aborted = true; }
+    };
+    const folderHandle = {
+        async getFileHandle(name, options) {
+            assert.equal(name, 'song.flac');
+            assert.equal(options.create, true);
+            return {
+                async createWritable() { return writable; }
+            };
+        },
+        async removeEntry(name) { removedName = name; }
+    };
+
+    await assert.rejects(
+        context.ml_write_blob_to_folder(folderHandle, 'song.flac', { size: 1024 }),
+        (caught) => caught === error && caught.mlFolderWriteStage === 'write'
+    );
+    assert.equal(aborted, true);
+    assert.equal(removedName, 'song.flac');
+    assert.equal(context.ml_is_storage_io_error(error), true);
+    assert.equal(context.ml_is_folder_write_blocked_error(error), false);
+});
+
+test('folder handle acquisition failure does not delete an unrelated file', async () => {
+    const context = loadScript('static/ml-task-manager.js');
+    let removeCalled = false;
+    const error = new DOMException('Permission denied', 'NotAllowedError');
+    const folderHandle = {
+        async getFileHandle() { throw error; },
+        async removeEntry() { removeCalled = true; }
+    };
+
+    await assert.rejects(
+        context.ml_write_blob_to_folder(folderHandle, 'song.flac', { size: 1024 }),
+        (caught) => caught === error && caught.mlFolderWriteStage === 'get-file-handle'
+    );
+    assert.equal(removeCalled, false);
+    assert.equal(context.ml_is_folder_write_blocked_error(error), true);
+});
+
+test('browser-managed and direct-folder tasks use different completion semantics', () => {
+    const context = loadScript('static/ml-task-manager.js');
+
+    assert.equal(context.ml_task_uses_browser_download({ type: 'single', outputMode: 'individual' }), true);
+    assert.equal(context.ml_task_uses_browser_download({ type: 'batch', outputMode: 'zip' }), true);
+    assert.equal(context.ml_task_uses_browser_download({ type: 'batch', outputMode: 'folder' }), false);
+});


### PR DESCRIPTION
Try to address the large zip file download issue.

- Improve download pipeline and logic.
- Add Beta tag beside download as zip button.

> Note that the problem (#19 ) originates from large file size of the zip file (which remains in the browser tab's memory). This is an unavoidable, hard-to-fix issue.